### PR TITLE
Adding decoding for basic instructions

### DIFF
--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -22,6 +22,7 @@ enum AhoyInstruction {
     CallSubroutine(u16),
     SetRegister(RegisterInstruction),
     AddToRegister(RegisterInstruction),
+    SetIndex(u16),
     UnknownInstruction,
 }
 impl From<u16> for AhoyInstruction {
@@ -34,6 +35,7 @@ impl From<u16> for AhoyInstruction {
                 2 => Self::CallSubroutine(instruction & 0x0FFF),
                 6 => Self::SetRegister(RegisterInstruction::from(instruction)),
                 7 => Self::AddToRegister(RegisterInstruction::from(instruction)),
+                10 => Self::SetIndex(instruction & 0x0FFF),
                 _ => Self::UnknownInstruction,
             },
         }
@@ -121,5 +123,12 @@ mod tests {
             0x2000.into(),
             AhoyInstruction::CallSubroutine(0x000)
         ));
+    }
+
+    #[test]
+    fn decode_set_index_instruction() {
+        assert!(matches!(0xAFE0.into(), AhoyInstruction::SetIndex(0xFE0)));
+        assert!(matches!(0xAABC.into(), AhoyInstruction::SetIndex(0xABC)));
+        assert!(matches!(0xA000.into(), AhoyInstruction::SetIndex(0x000)));
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,0 +1,28 @@
+#[derive(Debug)]
+struct JumpInstruction(u16);
+
+#[repr(u16)]
+#[derive(Debug)]
+enum AhoyInstruction {
+    ClearScreen = 0x00E0,
+    Jump(JumpInstruction),
+    UnknownInstruction,
+}
+impl From<u16> for AhoyInstruction {
+    fn from(value: u16) -> Self {
+        match value {
+            0x00E0 => Self::ClearScreen,
+            _ => Self::UnknownInstruction,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::instructions::*;
+
+    #[test]
+    fn from_decodes_static_instructions() {
+        assert!(matches!(0x00E0.into(), AhoyInstruction::ClearScreen));
+    }
+}

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -8,9 +8,11 @@ enum AhoyInstruction {
 impl From<u16> for AhoyInstruction {
     fn from(value: u16) -> Self {
         match value {
-            instruction if instruction >> 0xC == 1 => Self::Jump(instruction & 0x0FFF),
             0x00E0 => Self::ClearScreen,
-            _ => Self::UnknownInstruction,
+            instruction => match instruction >> 0xC {
+                1 => Self::Jump(instruction & 0x0FFF),
+                _ => Self::UnknownInstruction,
+            },
         }
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -18,6 +18,7 @@ impl From<u16> for RegisterInstruction {
 enum AhoyInstruction {
     ClearScreen = 0x00E0,
     Jump(u16),
+    RunSubroutine(u16),
     SetRegister(RegisterInstruction),
     AddToRegister(RegisterInstruction),
     UnknownInstruction,
@@ -28,6 +29,7 @@ impl From<u16> for AhoyInstruction {
             0x00E0 => Self::ClearScreen,
             instruction => match instruction >> 0xC {
                 1 => Self::Jump(instruction & 0x0FFF),
+                2 => Self::RunSubroutine(instruction & 0x0FFF),
                 6 => Self::SetRegister(RegisterInstruction::from(instruction)),
                 7 => Self::AddToRegister(RegisterInstruction::from(instruction)),
                 _ => Self::UnknownInstruction,
@@ -99,6 +101,22 @@ mod tests {
                 register: 0xB,
                 value: 0xEE
             })
+        ));
+    }
+
+    #[test]
+    fn decode_run_subroutine_instruction() {
+        assert!(matches!(
+            0x2FE0.into(),
+            AhoyInstruction::RunSubroutine(0xFE0)
+        ));
+        assert!(matches!(
+            0x2ABC.into(),
+            AhoyInstruction::RunSubroutine(0xABC)
+        ));
+        assert!(matches!(
+            0x2000.into(),
+            AhoyInstruction::RunSubroutine(0x000)
         ));
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,16 +1,14 @@
-#[derive(Debug)]
-struct JumpInstruction(u16);
-
 #[repr(u16)]
 #[derive(Debug)]
 enum AhoyInstruction {
     ClearScreen = 0x00E0,
-    Jump(JumpInstruction),
+    Jump(u16),
     UnknownInstruction,
 }
 impl From<u16> for AhoyInstruction {
     fn from(value: u16) -> Self {
         match value {
+            instruction if instruction >> 0xC == 1 => Self::Jump(instruction & 0x0FFF),
             0x00E0 => Self::ClearScreen,
             _ => Self::UnknownInstruction,
         }
@@ -24,5 +22,14 @@ mod tests {
     #[test]
     fn from_decodes_static_instructions() {
         assert!(matches!(0x00E0.into(), AhoyInstruction::ClearScreen));
+    }
+
+    #[test]
+    fn from_decode_jump_instruction() {
+        assert!(matches!(0x1FE0.into(), AhoyInstruction::Jump(0xFE0)));
+        assert!(matches!(0x1ABC.into(), AhoyInstruction::Jump(0xABC)));
+        assert!(matches!(0x1000.into(), AhoyInstruction::Jump(0x000)));
+
+        assert!(!matches!(0x2ABC.into(), AhoyInstruction::Jump(0xABC)));
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -17,6 +17,7 @@ impl From<u16> for RegisterInstruction {
 #[derive(Debug)]
 enum AhoyInstruction {
     ClearScreen = 0x00E0,
+    StopSubroutine = 0x00EE,
     Jump(u16),
     CallSubroutine(u16),
     SetRegister(RegisterInstruction),
@@ -27,6 +28,7 @@ impl From<u16> for AhoyInstruction {
     fn from(value: u16) -> Self {
         match value {
             0x00E0 => Self::ClearScreen,
+            0x00EE => Self::StopSubroutine,
             instruction => match instruction >> 0xC {
                 1 => Self::Jump(instruction & 0x0FFF),
                 2 => Self::CallSubroutine(instruction & 0x0FFF),
@@ -45,6 +47,7 @@ mod tests {
     #[test]
     fn decode_static_instructions() {
         assert!(matches!(0x00E0.into(), AhoyInstruction::ClearScreen));
+        assert!(matches!(0x00EE.into(), AhoyInstruction::StopSubroutine));
     }
 
     #[test]

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -3,6 +3,7 @@
 enum AhoyInstruction {
     ClearScreen = 0x00E0,
     Jump(u16),
+    SetRegister { register: u8, value: u8 },
     UnknownInstruction,
 }
 impl From<u16> for AhoyInstruction {
@@ -11,6 +12,14 @@ impl From<u16> for AhoyInstruction {
             0x00E0 => Self::ClearScreen,
             instruction => match instruction >> 0xC {
                 1 => Self::Jump(instruction & 0x0FFF),
+                6 => {
+                    let payload = instruction & 0x0FFF;
+                    Self::SetRegister {
+                        register: (payload >> 8) as u8,
+                        value: (payload & 0x0FF) as u8,
+                    }
+                }
+
                 _ => Self::UnknownInstruction,
             },
         }
@@ -31,7 +40,30 @@ mod tests {
         assert!(matches!(0x1FE0.into(), AhoyInstruction::Jump(0xFE0)));
         assert!(matches!(0x1ABC.into(), AhoyInstruction::Jump(0xABC)));
         assert!(matches!(0x1000.into(), AhoyInstruction::Jump(0x000)));
+    }
 
-        assert!(!matches!(0x2ABC.into(), AhoyInstruction::Jump(0xABC)));
+    #[test]
+    fn from_decode_set_register_instruction() {
+        assert!(matches!(
+            0x6FE0.into(),
+            AhoyInstruction::SetRegister {
+                register: 0xF,
+                value: 0xE0
+            }
+        ));
+        assert!(matches!(
+            0x6EEE.into(),
+            AhoyInstruction::SetRegister {
+                register: 0xE,
+                value: 0xEE
+            }
+        ));
+        assert!(matches!(
+            0x6A00.into(),
+            AhoyInstruction::SetRegister {
+                register: 0xA,
+                value: 0x00
+            }
+        ));
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -42,8 +42,8 @@ impl From<u16> for AhoyInstruction {
                 7 => Self::AddToRegister(RegisterInstruction::from(instruction)),
                 0xA => Self::SetIndex(instruction & 0x0FFF),
                 0xD => Self::Display {
-                    x_register: ((instruction & 0xF00) >> 8) as u8,
-                    y_register: ((instruction & 0xF0) >> 4) as u8,
+                    x_register: ((instruction >> 8) & 0xF) as u8,
+                    y_register: ((instruction >> 4) & 0xF) as u8,
                     sprite_height: (instruction & 0xF) as u8,
                 },
                 _ => Self::UnknownInstruction,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -4,6 +4,7 @@ enum AhoyInstruction {
     ClearScreen = 0x00E0,
     Jump(u16),
     SetRegister { register: u8, value: u8 },
+    AddToRegister { register: u8, value: u8 },
     UnknownInstruction,
 }
 impl From<u16> for AhoyInstruction {
@@ -15,6 +16,13 @@ impl From<u16> for AhoyInstruction {
                 6 => {
                     let payload = instruction & 0x0FFF;
                     Self::SetRegister {
+                        register: (payload >> 8) as u8,
+                        value: (payload & 0x0FF) as u8,
+                    }
+                }
+                7 => {
+                    let payload = instruction & 0x0FFF;
+                    Self::AddToRegister {
                         register: (payload >> 8) as u8,
                         value: (payload & 0x0FF) as u8,
                     }
@@ -31,19 +39,19 @@ mod tests {
     use crate::instructions::*;
 
     #[test]
-    fn from_decodes_static_instructions() {
+    fn decode_static_instructions() {
         assert!(matches!(0x00E0.into(), AhoyInstruction::ClearScreen));
     }
 
     #[test]
-    fn from_decode_jump_instruction() {
+    fn decode_jump_instruction() {
         assert!(matches!(0x1FE0.into(), AhoyInstruction::Jump(0xFE0)));
         assert!(matches!(0x1ABC.into(), AhoyInstruction::Jump(0xABC)));
         assert!(matches!(0x1000.into(), AhoyInstruction::Jump(0x000)));
     }
 
     #[test]
-    fn from_decode_set_register_instruction() {
+    fn decode_set_register_instruction() {
         assert!(matches!(
             0x6FE0.into(),
             AhoyInstruction::SetRegister {
@@ -63,6 +71,31 @@ mod tests {
             AhoyInstruction::SetRegister {
                 register: 0xA,
                 value: 0x00
+            }
+        ));
+    }
+
+    #[test]
+    fn decode_add_value_to_register_instruction() {
+        assert!(matches!(
+            0x7808.into(),
+            AhoyInstruction::AddToRegister {
+                register: 0x8,
+                value: 0x8
+            }
+        ));
+        assert!(matches!(
+            0x7D1E.into(),
+            AhoyInstruction::AddToRegister {
+                register: 0xD,
+                value: 0x1E
+            }
+        ));
+        assert!(matches!(
+            0x7BEE.into(),
+            AhoyInstruction::AddToRegister {
+                register: 0xB,
+                value: 0xEE
             }
         ));
     }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -18,7 +18,7 @@ impl From<u16> for RegisterInstruction {
 enum AhoyInstruction {
     ClearScreen = 0x00E0,
     Jump(u16),
-    RunSubroutine(u16),
+    CallSubroutine(u16),
     SetRegister(RegisterInstruction),
     AddToRegister(RegisterInstruction),
     UnknownInstruction,
@@ -29,7 +29,7 @@ impl From<u16> for AhoyInstruction {
             0x00E0 => Self::ClearScreen,
             instruction => match instruction >> 0xC {
                 1 => Self::Jump(instruction & 0x0FFF),
-                2 => Self::RunSubroutine(instruction & 0x0FFF),
+                2 => Self::CallSubroutine(instruction & 0x0FFF),
                 6 => Self::SetRegister(RegisterInstruction::from(instruction)),
                 7 => Self::AddToRegister(RegisterInstruction::from(instruction)),
                 _ => Self::UnknownInstruction,
@@ -108,15 +108,15 @@ mod tests {
     fn decode_run_subroutine_instruction() {
         assert!(matches!(
             0x2FE0.into(),
-            AhoyInstruction::RunSubroutine(0xFE0)
+            AhoyInstruction::CallSubroutine(0xFE0)
         ));
         assert!(matches!(
             0x2ABC.into(),
-            AhoyInstruction::RunSubroutine(0xABC)
+            AhoyInstruction::CallSubroutine(0xABC)
         ));
         assert!(matches!(
             0x2000.into(),
-            AhoyInstruction::RunSubroutine(0x000)
+            AhoyInstruction::CallSubroutine(0x000)
         ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@ use anyhow::anyhow;
 use std::{collections::VecDeque, io::BufRead};
 
 const PROGRAM_MEMORY_START: usize = 0x200;
-const AVAILABLE_PROGRAM_MEMORY: usize = 0x1000 - PROGRAM_MEMORY_START;
+const MAX_MEMORY: usize = 0x1000;
+const AVAILABLE_PROGRAM_MEMORY: usize = MAX_MEMORY - PROGRAM_MEMORY_START;
 const FONT: [u8; 80] = [
     0xF0, 0x90, 0x90, 0x90, 0xF0, 0x20, 0x60, 0x20, 0x20, 0x70, 0xF0, 0x10, 0xF0, 0x80, 0xF0, 0xF0,
     0x10, 0xF0, 0x10, 0xF0, 0x90, 0x90, 0xF0, 0x10, 0x10, 0xF0, 0x80, 0xF0, 0x10, 0xF0, 0xF0, 0x80,
@@ -10,12 +11,25 @@ const FONT: [u8; 80] = [
     0x10, 0xF0, 0xF0, 0x90, 0xF0, 0x90, 0x90, 0xE0, 0x90, 0xE0, 0x90, 0xE0, 0xF0, 0x80, 0x80, 0x80,
     0xF0, 0xE0, 0x90, 0x90, 0x90, 0xE0, 0xF0, 0x80, 0xF0, 0x80, 0xF0, 0xF0, 0x80, 0xF0, 0x80, 0x80,
 ];
-type AhoyInstruction = u16;
 
-const MEMORY_CAPACITY: usize = 0x1000;
+#[derive(Debug)]
+struct JumpInstruction(u16);
+
+#[repr(u16)]
+#[derive(Debug)]
+enum AhoyInstruction {
+    ClearScreen = 0x00E0,
+    Jump(JumpInstruction),
+    UnknownInstruction,
+}
+impl From<u16> for AhoyInstruction {
+    fn from(value: u16) -> Self {
+        Self::UnknownInstruction
+    }
+}
 
 pub struct Ahoy {
-    memory: [u8; MEMORY_CAPACITY],
+    memory: [u8; MAX_MEMORY],
     index: u16,
     counter: u16,
     stack: VecDeque<u16>,
@@ -25,7 +39,7 @@ pub struct Ahoy {
 
 impl Ahoy {
     fn new() -> Self {
-        let mut memory = [0; MEMORY_CAPACITY];
+        let mut memory = [0; MAX_MEMORY];
 
         memory[0x050..=0x09F].copy_from_slice(&FONT);
 
@@ -62,7 +76,7 @@ impl Ahoy {
         Ok(())
     }
 
-    fn fetch(&mut self) -> AhoyInstruction {
+    fn fetch(&mut self) -> u16 {
         let usize_counter = self.counter as usize;
 
         let first_nibble: u16 = self.memory[usize_counter].into();
@@ -70,8 +84,12 @@ impl Ahoy {
 
         let instruction = (first_nibble << 8) | second_nibble;
 
-        self.counter = (self.counter + 2) % (MEMORY_CAPACITY as u16);
+        self.counter = (self.counter + 2) % (MAX_MEMORY as u16);
         instruction
+    }
+
+    fn decode(&self, instruction: u16) -> AhoyInstruction {
+        instruction.into()
     }
 }
 
@@ -79,7 +97,7 @@ impl Ahoy {
 mod tests {
     use std::io::{BufReader, Cursor};
 
-    use crate::Ahoy;
+    use crate::{Ahoy, AhoyInstruction};
 
     #[test]
     fn load_normal_program() {
@@ -163,5 +181,12 @@ mod tests {
         let actual_instruction = chip8.fetch();
 
         assert_eq!(expected_instruction, actual_instruction);
+    }
+
+    #[test]
+    fn decode_identifies_the_instruction_by_the_first_nibble() {
+        let chip8 = Ahoy::new();
+
+        assert!(matches!(chip8.decode(0x00E0), AhoyInstruction::ClearScreen));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+mod instructions;
+
 use anyhow::anyhow;
 use std::{collections::VecDeque, io::BufRead};
 
@@ -11,22 +13,6 @@ const FONT: [u8; 80] = [
     0x10, 0xF0, 0xF0, 0x90, 0xF0, 0x90, 0x90, 0xE0, 0x90, 0xE0, 0x90, 0xE0, 0xF0, 0x80, 0x80, 0x80,
     0xF0, 0xE0, 0x90, 0x90, 0x90, 0xE0, 0xF0, 0x80, 0xF0, 0x80, 0xF0, 0xF0, 0x80, 0xF0, 0x80, 0x80,
 ];
-
-#[derive(Debug)]
-struct JumpInstruction(u16);
-
-#[repr(u16)]
-#[derive(Debug)]
-enum AhoyInstruction {
-    ClearScreen = 0x00E0,
-    Jump(JumpInstruction),
-    UnknownInstruction,
-}
-impl From<u16> for AhoyInstruction {
-    fn from(value: u16) -> Self {
-        Self::UnknownInstruction
-    }
-}
 
 pub struct Ahoy {
     memory: [u8; MAX_MEMORY],
@@ -87,17 +73,13 @@ impl Ahoy {
         self.counter = (self.counter + 2) % (MAX_MEMORY as u16);
         instruction
     }
-
-    fn decode(&self, instruction: u16) -> AhoyInstruction {
-        instruction.into()
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::io::{BufReader, Cursor};
 
-    use crate::{Ahoy, AhoyInstruction};
+    use crate::Ahoy;
 
     #[test]
     fn load_normal_program() {
@@ -181,12 +163,5 @@ mod tests {
         let actual_instruction = chip8.fetch();
 
         assert_eq!(expected_instruction, actual_instruction);
-    }
-
-    #[test]
-    fn decode_identifies_the_instruction_by_the_first_nibble() {
-        let chip8 = Ahoy::new();
-
-        assert!(matches!(chip8.decode(0x00E0), AhoyInstruction::ClearScreen));
     }
 }


### PR DESCRIPTION
# What does it include?
## Features
- Add decoding for the following instructions:
    - Clear Screen
    - Jump
    - Set Register
    - Add Value to Register
    - Call Subroutine
    - Return From a Subroutine
    - Set the index register
    - Display

# What it DOESN'T include?
## Features
- Execution of any of these instructions
