### PR TITLE
Add Clear Screen Execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# CHIP-8 Emulator
+# CHIP-8 Interpreter
+
+An interpreter for CHIP-8 instructions based on the explanations from [Tobias V. Langhoff](https://tobiasvl.github.io/blog/write-a-chip-8-emulator)
+
+> __DISCLAIMER__:
+> This is a didactical project to further my knowledge in Rust and how emulators are created

--- a/src/display.rs
+++ b/src/display.rs
@@ -3,10 +3,10 @@ use ratatui::{
     widgets::canvas::{Canvas, Rectangle},
 };
 
-pub type Frame = [u64; 32];
+pub type AhoyFrame = [u64; 32];
 
 pub trait AhoyDisplay {
-    fn draw(&mut self, frame: &Frame) -> anyhow::Result<()>;
+    fn draw(&mut self, frame: &AhoyFrame) -> anyhow::Result<()>;
 }
 
 pub struct RatatuiAhoyDisplay {
@@ -49,7 +49,7 @@ impl Default for Size {
 }
 
 impl AhoyDisplay for RatatuiAhoyDisplay {
-    fn draw(&mut self, frame: &Frame) -> anyhow::Result<()> {
+    fn draw(&mut self, frame: &AhoyFrame) -> anyhow::Result<()> {
         let rectangle_size = Size::default().scale(10.0);
         let display_size = Size::new(
             64_f64 * rectangle_size.width,

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -17,7 +17,7 @@ impl From<u16> for RegisterInstruction {
 
 #[repr(u16)]
 #[derive(Debug)]
-enum AhoyInstruction {
+pub enum AhoyInstruction {
     Jump(u16),
     CallSubroutine(u16),
     SetRegister(RegisterInstruction),
@@ -32,12 +32,7 @@ enum AhoyInstruction {
     StopSubroutine = 0x00EE,
     UnknownInstruction,
 }
-impl AhoyInstruction {
-    pub fn execute(&self, ahoy: &mut Ahoy) -> anyhow::Result<()> {
-        ahoy.current_frame = [0; 32];
-        Ok(())
-    }
-}
+
 impl From<u16> for AhoyInstruction {
     fn from(value: u16) -> Self {
         match value {
@@ -176,19 +171,5 @@ mod tests {
                 sprite_height: 8
             }
         ));
-    }
-
-    #[test]
-    fn clear_screen_sets_frame_to_zeroes() {
-        let mut ahoy = Ahoy {
-            current_frame: [1; 32],
-            ..Default::default()
-        };
-
-        AhoyInstruction::ClearScreen
-            .execute(&mut ahoy)
-            .expect("should not throw error");
-
-        assert_eq!(ahoy.current_frame, [0_u64; 32]);
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -34,6 +34,7 @@ enum AhoyInstruction {
 }
 impl AhoyInstruction {
     pub fn execute(&self, ahoy: &mut Ahoy) -> anyhow::Result<()> {
+        ahoy.current_frame = [0; 32];
         Ok(())
     }
 }

--- a/src/instructions.rs
+++ b/src/instructions.rs
@@ -1,3 +1,5 @@
+use crate::Ahoy;
+
 #[derive(Debug)]
 struct RegisterInstruction {
     register: u8,
@@ -29,6 +31,11 @@ enum AhoyInstruction {
     ClearScreen = 0x00E0,
     StopSubroutine = 0x00EE,
     UnknownInstruction,
+}
+impl AhoyInstruction {
+    pub fn execute(&self, ahoy: &mut Ahoy) -> anyhow::Result<()> {
+        Ok(())
+    }
 }
 impl From<u16> for AhoyInstruction {
     fn from(value: u16) -> Self {
@@ -168,5 +175,19 @@ mod tests {
                 sprite_height: 8
             }
         ));
+    }
+
+    #[test]
+    fn clear_screen_sets_frame_to_zeroes() {
+        let mut ahoy = Ahoy {
+            current_frame: [1; 32],
+            ..Default::default()
+        };
+
+        AhoyInstruction::ClearScreen
+            .execute(&mut ahoy)
+            .expect("should not throw error");
+
+        assert_eq!(ahoy.current_frame, [0_u64; 32]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ mod instructions;
 
 use anyhow::anyhow;
 use display::AhoyFrame;
+use instructions::AhoyInstruction;
 use std::{collections::VecDeque, io::BufRead};
 
 const PROGRAM_MEMORY_START: usize = 0x200;
@@ -79,13 +80,23 @@ impl Ahoy {
         self.counter = (self.counter + 2) % (MAX_MEMORY as u16);
         instruction
     }
+
+    fn execute(&mut self, instruction: AhoyInstruction) -> anyhow::Result<()> {
+        match instruction {
+            AhoyInstruction::ClearScreen => {
+                self.current_frame = [0; 32];
+            }
+            _ => todo!(),
+        };
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::io::{BufReader, Cursor};
 
-    use crate::Ahoy;
+    use crate::{Ahoy, instructions::AhoyInstruction};
 
     #[test]
     fn load_normal_program() {
@@ -175,5 +186,17 @@ mod tests {
         let actual_instruction = chip8.fetch();
 
         assert_eq!(expected_instruction, actual_instruction);
+    }
+
+    #[test]
+    fn clear_screen_sets_frame_to_zeroes() {
+        let mut ahoy = Ahoy {
+            current_frame: [1; 32],
+            ..Default::default()
+        };
+        ahoy.execute(AhoyInstruction::ClearScreen)
+            .expect("should not throw error");
+
+        assert_eq!(ahoy.current_frame, [0_u64; 32]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
+mod display;
 mod instructions;
 
 use anyhow::anyhow;
+use display::AhoyFrame;
 use std::{collections::VecDeque, io::BufRead};
 
 const PROGRAM_MEMORY_START: usize = 0x200;
@@ -21,6 +23,7 @@ pub struct Ahoy {
     stack: VecDeque<u16>,
     delay_timer: u8,
     sound_timer: u8,
+    current_frame: AhoyFrame,
 }
 
 impl Default for Ahoy {
@@ -36,6 +39,7 @@ impl Default for Ahoy {
             stack: VecDeque::with_capacity(256),
             delay_timer: 0,
             sound_timer: 0,
+            current_frame: [0; 32],
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,90 +100,88 @@ mod tests {
 
     #[test]
     fn load_normal_program() {
-        let mut chip8 = Ahoy::default();
+        let mut ahoy = Ahoy::default();
         let mut program_reader = BufReader::new(Cursor::new([
             0x01_u8, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A,
         ]));
 
-        chip8.load(&mut program_reader).unwrap();
+        ahoy.load(&mut program_reader).unwrap();
 
-        assert_eq!(chip8.memory[0x200], 0x01);
-        assert_eq!(chip8.memory[0x201], 0x02);
-        assert_eq!(chip8.memory[0x202], 0x03);
-        assert_eq!(chip8.memory[0x203], 0x04);
-        assert_eq!(chip8.memory[0x204], 0x05);
-        assert_eq!(chip8.memory[0x205], 0x06);
-        assert_eq!(chip8.memory[0x206], 0x07);
-        assert_eq!(chip8.memory[0x207], 0x08);
-        assert_eq!(chip8.memory[0x208], 0x09);
-        assert_eq!(chip8.memory[0x209], 0x0A);
+        assert_eq!(ahoy.memory[0x200], 0x01);
+        assert_eq!(ahoy.memory[0x201], 0x02);
+        assert_eq!(ahoy.memory[0x202], 0x03);
+        assert_eq!(ahoy.memory[0x203], 0x04);
+        assert_eq!(ahoy.memory[0x204], 0x05);
+        assert_eq!(ahoy.memory[0x205], 0x06);
+        assert_eq!(ahoy.memory[0x206], 0x07);
+        assert_eq!(ahoy.memory[0x207], 0x08);
+        assert_eq!(ahoy.memory[0x208], 0x09);
+        assert_eq!(ahoy.memory[0x209], 0x0A);
     }
 
     #[test]
     fn load_returns_error_for_empty_file() {
-        let mut chip8 = Ahoy::default();
+        let mut ahoy = Ahoy::default();
         let mut program_reader = BufReader::new(Cursor::new([]));
 
-        chip8
-            .load(&mut program_reader)
+        ahoy.load(&mut program_reader)
             .expect_err("Expected empty program to raise error");
     }
 
     #[test]
     fn load_returns_error_for_larger_than_buffer_file() {
-        let mut chip8 = Ahoy::default();
+        let mut ahoy = Ahoy::default();
         let mut program_reader = BufReader::new(Cursor::new([1u8; 4096]));
 
-        chip8
-            .load(&mut program_reader)
+        ahoy.load(&mut program_reader)
             .expect_err("Expected large program to raise error");
     }
 
     #[test]
     fn fetch_increments_program_counter_by_two() {
-        let mut chip8 = Ahoy::default();
+        let mut ahoy = Ahoy::default();
 
-        chip8.fetch();
-        assert_eq!(chip8.counter, 2u16);
+        ahoy.fetch();
+        assert_eq!(ahoy.counter, 2u16);
 
-        chip8.fetch();
-        assert_eq!(chip8.counter, 4u16);
+        ahoy.fetch();
+        assert_eq!(ahoy.counter, 4u16);
     }
 
     #[test]
     fn fetch_loops_back_program_counter_to_zero_when_overflowing_12bits() {
-        let mut chip8 = Ahoy {
+        let mut ahoy = Ahoy {
             counter: 4094,
             ..Default::default()
         };
 
-        chip8.fetch();
-        assert_eq!(chip8.counter, 0);
+        ahoy.fetch();
+        assert_eq!(ahoy.counter, 0);
 
-        chip8.fetch();
-        assert_eq!(chip8.counter, 2);
+        ahoy.fetch();
+        assert_eq!(ahoy.counter, 2);
     }
     #[test]
     fn fetch_retrieves_expected_bytes_from_memory_beginning() {
-        let mut chip8 = Ahoy::default();
-        chip8.memory[0..2].copy_from_slice(&[0xF0, 0x0F]);
+        let mut ahoy = Ahoy::default();
+        ahoy.memory[0..2].copy_from_slice(&[0xF0, 0x0F]);
 
         let expected_instruction = 0xF00F;
 
-        let actual_instruction = chip8.fetch();
+        let actual_instruction = ahoy.fetch();
         assert_eq!(expected_instruction, actual_instruction);
     }
 
     #[test]
     fn fetch_retrieves_expected_bytes_from_arbitrary_position() {
-        let mut chip8 = Ahoy {
+        let mut ahoy = Ahoy {
             counter: 0x6F,
             ..Default::default()
         };
-        chip8.memory[0x6F..0x73].copy_from_slice(&[0xAB, 0xBC, 0xCD, 0xDE]);
+        ahoy.memory[0x6F..0x73].copy_from_slice(&[0xAB, 0xBC, 0xCD, 0xDE]);
 
         let expected_instruction = 0xABBC;
-        let actual_instruction = chip8.fetch();
+        let actual_instruction = ahoy.fetch();
 
         assert_eq!(expected_instruction, actual_instruction);
     }


### PR DESCRIPTION
## What's included?
- New `execute` method for `Ahoy` to run the set of instructions
- New `current_frame` member in `Ahoy` to represent the current displayed frame

## What's missing?
- Setting up the pipeline `fetch` -> `decode` -> `execute` for a whole instruction.
- A loop to paint the current screen to the display
- Connecting `Ahoy` to `AhoyDisplay`
